### PR TITLE
Modify installation package list for CentOS 6.5.

### DIFF
--- a/doc/install-rhel.rst
+++ b/doc/install-rhel.rst
@@ -39,7 +39,7 @@ Installing The Hypervisor
 
 ::
 
-  yum install kvm kvm-qemu-img python-virtinst
+  yum install kvm libvirt python-virtinst
 
 - Xen on RHEL/CentOS/Scientific Linux
 


### PR DESCRIPTION
I followed the installation instruction and see an error in the step

yum install kvm kvm-qemu-img python-virtinst

and

chkconfig libvirtd on

After installing libvirt the error is gone. I have tested this with CentOS 6.5.
