### PR TITLE
Update install-rhel.rst

### DIFF
--- a/doc/install-rhel.rst
+++ b/doc/install-rhel.rst
@@ -59,6 +59,9 @@ Service configuration::
   chkconfig messagebus on
   chkconfig libvirtd on
   chkconfig libvirt-guests off
+  
+Install brctl::
+  yum install bridge-utils
 
 Create bridge interface
 


### PR DESCRIPTION
On minimal installation bridge-utils is not installed and without brctl bridge configuration fails.
