### PR TITLE
Patch for add -rtsopts to HFLAGS.

### DIFF
--- a/rpmbuild/ganeti/SOURCES/ganeti-2.16.2-add-rtsopts-hflags.patch
+++ b/rpmbuild/ganeti/SOURCES/ganeti-2.16.2-add-rtsopts-hflags.patch
@@ -1,0 +1,11 @@
+--- ganeti-2.16.2/Makefile.in	2020-05-22 15:44:58.000000000 +0000
++++ ganeti-2.16.2.b/Makefile.in	2020-10-21 08:50:15.000000000 +0000
+@@ -1228,7 +1228,7 @@
+ HS_SRC_PROGS = $(filter-out test/%,$(HS_ALL_PROGS))
+ HS_PROG_SRCS = $(patsubst %,%.hs,$(HS_DEFAULT_PROGS)) src/mon-collector.hs
+ HS_BUILT_TEST_HELPERS = $(HS_BIN_ROLES:%=test/hs/%) test/hs/hail
+-HFLAGS = -O -Wall -isrc -fwarn-monomorphism-restriction -fwarn-tabs \
++HFLAGS = -O -Wall -isrc -fwarn-monomorphism-restriction -fwarn-tabs -rtsopts \
+ 	-optP-include -optP$(HASKELL_PACKAGE_VERSIONS_FILE) \
+ 	-hide-all-packages `cat $(HASKELL_PACKAGE_IDS_FILE)` \
+ 	$(GHC_BYVERSION_FLAGS) $(am__append_12) $(am__append_13)

--- a/rpmbuild/ganeti/SPECS/ganeti.spec
+++ b/rpmbuild/ganeti/SPECS/ganeti.spec
@@ -39,6 +39,7 @@ Patch7: ganeti-2.16.1-rapi-require-authentication.patch
 Patch8: ganeti-2.16.1-systemd-ambient-capabilities.patch
 Patch9: ganeti-2.16.1-ask-whether-upgrade-without-rpm.patch
 Patch10: ganeti-2.16.2-vlan_aware_bridge-1395.patch
+Patch11: ganeti-2.16.2-add-rtsopts-hflags.patch
 
 BuildRequires: python
 BuildRequires: pyOpenSSL
@@ -149,6 +150,7 @@ It is not required when the init system used is systemd.
 %patch8 -p1
 %patch9 -p1
 %patch10 -p1
+%patch11 -p1
 
 %build
 %configure \


### PR DESCRIPTION
I have made this patch to avoid problems running htols in some
conditions under Centos 7.8.
Without the patch:
[root@g1 ~]# hspace -m 10.10.223.170 --disk-template=drbd --standard-alloc=1000480,32048,24 -q
The cluster has 3 nodes and the following resources:
  MEM 773343, DSK 11445588, CPU 192, VCPU 768.
There are 4 initial instances on the cluster.
Stack space overflow: current size 8388608 bytes.
Use `+RTS -Ksize -RTS' to increase it.
[root@g1 ~]# hspace -m 10.10.223.170 --disk-template=drbd --standard-alloc=1000480,32048,24 -q +RTS -K9388608 -RTS
hspace: Most RTS options are disabled. Link with -rtsopts to enable them.
[root@g1 ~]#

With rts patch:
[root@--rm rpmbuild]# hspace -m 10.10.223.170 --disk-template=drbd --standard-alloc=1000480,32048,24 -q
The cluster has 3 nodes and the following resources:
  MEM 773343, DSK 11445588, CPU 192, VCPU 768.
There are 4 initial instances on the cluster.
Stack space overflow: current size 8388608 bytes.
Use `+RTS -Ksize -RTS' to increase it.
[root@--rm rpmbuild]# hspace -m 10.10.223.170 --disk-template=drbd --standard-alloc=1000480,32048,24 -q +RTS -K18388608 -RTS
The cluster has 3 nodes and the following resources:
  MEM 773343, DSK 11445588, CPU 192, VCPU 768.
There are 4 initial instances on the cluster.
Tiered (initial size) instance spec is:
  MEM 235520, DSK 31457280, CPU 240, using disk template 'drbd'.
Tiered allocation results:
  -   1 instances of spec MEM 229952, DSK 3702272, CPU 176
  -   1 instances of spec MEM 10496, DSK 256, CPU 176
  - most likely failure reason: FailMem
  - initial cluster score: 1.98297895
  -   final cluster score: 5.72387336
  - memory usage efficiency: 34.27%
  -   disk usage efficiency: 67.16%
  -   vcpu usage efficiency: 77.08%
Standard (fixed-size) instance spec is:
  MEM 32048, DSK 1000480, CPU 24, using disk template 'drbd'.
Normal (fixed-size) allocation results:
  -   4 instances allocated
  - most likely failure reason: FailDisk
  - initial cluster score: 1.98297895
  -   final cluster score: 1.92495400
  - memory usage efficiency: 19.75%
  -   disk usage efficiency: 72.39%
  -   vcpu usage efficiency: 43.75%
[root@--rm rpmbuild]#

I know that it isn't the best way to correct it, but it works