### PR TITLE
New links to official Ganeti documentation

### DIFF
--- a/doc/install-rhel.md
+++ b/doc/install-rhel.md
@@ -4,7 +4,9 @@ This is a short guide for RHEL/AlmaLinux/Rocky Linux/others 8.x, 9.x, and 10.x.
 
 Official documentation:
 
-- [Ganeti's documentation](http://docs.ganeti.org/ganeti/current/html/) > [Ganeti installation tutorial](http://docs.ganeti.org/ganeti/current/html/install.html)
+- [Ganeti's documentation](https://docs.ganeti.org/docs/ganeti/3.1/html/)
+  - [Ganeti installation tutorial](https://docs.ganeti.org/docs/ganeti/3.1/html/install.html)
+  - [Ganeti upgrade notes](https://docs.ganeti.org/docs/ganeti/3.1/html/upgrade.html)
 
 Upgrade/update to the latest version:
 


### PR DESCRIPTION
The links to the Ganeti documentation is broken since the 3.1 release. New links added. Unfortunately the "current" link is missing so we need links to explicit versions of the upstream docs.